### PR TITLE
change php version requirements to >= 7.0 so php 8.2 can be used as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Frontend routing whitelist configurations for headless setups.",
   "license": "MIT",
   "require": {
-    "php": "^7.0 || ~8.1.0"
+    "php": ">=7.0"
   },
   "type": "magento2-module",
   "authors": [
@@ -19,5 +19,8 @@
     "psr-4": {
       "N98\\Guillotine\\": ""
     }
+  },
+  "require-dev": {
+    "rector/rector": "^0.17.7"
   }
 }


### PR DESCRIPTION
It's currently not possible to use the module with PHP 8.2 though I don't see any reason why it wouldn't be compatible if it's compatible with 8.1 already. Ran it through rector and no needed changes were found afaik.