### PR TITLE
change php version requirements to >= 7.0 so php 8.2 can be used as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Frontend routing whitelist configurations for headless setups.",
   "license": "MIT",
   "require": {
-    "php": "^7.0 || ~8.1.0"
+    "php": ">=7.0"
   },
   "type": "magento2-module",
   "authors": [

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -16,11 +16,6 @@
                 <whitelist_patterns><![CDATA[^/rest/.*$
 ^/(swagger|(swagger/.*))$
 ^/graphql/.*$
-^/mollie/.*$
-^/shipping/.*$
-^/robots.txt$
-^/favicon.ico$
-^/channable/.*$
 ]]></whitelist_patterns>
                 <throw_exception>1</throw_exception>
             </guillotine>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -16,6 +16,11 @@
                 <whitelist_patterns><![CDATA[^/rest/.*$
 ^/(swagger|(swagger/.*))$
 ^/graphql/.*$
+^/mollie/.*$
+^/shipping/.*$
+^/robots.txt$
+^/favicon.ico$
+^/channable/.*$
 ]]></whitelist_patterns>
                 <throw_exception>1</throw_exception>
             </guillotine>


### PR DESCRIPTION
Changing the PHP version requirements to >= 7.0 lets the module continue to be used with PHP 8.2